### PR TITLE
Simply assignment titles and home display

### DIFF
--- a/_labs/lab1.md
+++ b/_labs/lab1.md
@@ -1,14 +1,9 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab expressions functions
 ---
-
-CSci 1301: Lab 1
-----------------
-
-#### Due: Wednesday, September 12th at 11:59pm
 
 ### Prelude
 

--- a/_labs/lab2.md
+++ b/_labs/lab2.md
@@ -1,14 +1,9 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab
 ---
-
-CSci 1301: Lab 2
-----------------
-
-#### Due: Wednesday, September 26th at 11:59pm
 
 #### What to submit
 

--- a/_labs/lab3.md
+++ b/_labs/lab3.md
@@ -1,14 +1,9 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab
 ---
-
-CSci 1301: Lab 3
-----------------
-
-#### Due: Monday, October 8th at 11:59pm
 
 #### About this lab
 

--- a/_labs/lab4.md
+++ b/_labs/lab4.md
@@ -1,14 +1,9 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab
 ---
-
-CSci 1301: Lab 4
-----------------
-
-#### Due: Friday, October 19th at 11:59pm
 
 #### About this lab
 

--- a/_labs/lab5.md
+++ b/_labs/lab5.md
@@ -1,14 +1,9 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab
 ---
-
-CSci 1301: Lab 5
-----------------
-
-#### Due: Friday, November 2 at 11:59pm
 
 #### About this lab
 
@@ -33,7 +28,7 @@ otherwise:
           (check-expect (has-one-element? (list 2 3 5 6)) #false)
           (check-expect (has-one-element? empty) #false)
           (check-expect (has-one-element? (list 2)) #true)
-      
+
 
 **Question 2** Write a function `has-more-than-one-element?` that, given
 a list, returns `#true` if the list has more than one element, and
@@ -42,7 +37,7 @@ a list, returns `#true` if the list has more than one element, and
           (check-expect (has-more-than-one-element? (list 2 3 5 6)) #true)
           (check-expect (has-more-than-one-element? empty) #false)
           (check-expect (has-more-than-one-element? (list 2)) #false)
-      
+
 
 #### Task 2 (22 points)
 

--- a/_labs/lab6.md
+++ b/_labs/lab6.md
@@ -1,14 +1,9 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab
 ---
-
-CSci 1301: Lab 6
-----------------
-
-#### Due: Friday, November 9th at 11:59pm
 
 #### What to submit
 
@@ -22,12 +17,12 @@ multitude of randomly generated balloons that start at the botom of the
 screen and float up. The world state is a list of balloon structures.
 The structure is already defined in the file:
 
-      
+
         (define-struct balloon [x y size color])
 
         ;; example:
         (make-balloon 100 200 2.5 "blue")
-      
+
 
 The x and y are the coordinates of the balloon, size is its size
 relative to the example given in the file, and the color is its color.\

--- a/_labs/lab7.md
+++ b/_labs/lab7.md
@@ -1,16 +1,11 @@
 ---
 layout: lab
-title:  "CSci 1301: Lab XXX"
+title:  "Lab XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket lab
 ---
 
-CSci 1301: Lab 7
-----------------
-
-#### Due: Friday, November 30th at 11:59pm
-
-The lab is done in groups of 2 or 3.\
+The lab is done in groups of 2 or 3.
 Your goal is to explore abstraction by starting with two or three
 examples and generalizing to a function that takes another function as a
 parameter. Use examples on the [resources page](../resources.html) for
@@ -22,13 +17,13 @@ lambda** (even if you are not using `lambda`.
 Since we haven\'t spent much time on writing general signatures, you are
 not required to write them. However, correct signatures for the general
 functions in tasks 1 and 2 would give you **2 points of extra credit
-each** (and a good attempt would give you partial credit).\
+each** (and a good attempt would give you partial credit).
 Signatures for specific functions (for instance, functions that take a
 list of numbers) are **required**.
 
 #### Task 1: All elements satisfy a condition (10 points).
 
-1.  Write a fucntion takes a list of numbers and returns `#true` if all
+1.  Write a function takes a list of numbers and returns `#true` if all
     elements of the list are odd and `#false` otherwise. Make sure to
     test the function well.
 2.  Write a helper function take takes a string and returns `#true` if

--- a/_problem_sets/pset1.md
+++ b/_problem_sets/pset1.md
@@ -1,14 +1,9 @@
 ---
 layout: problem_set
-title:  "CSci 1301: Problem Set XXX"
+title:  "Problem Set XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket problem_set expressions functions images strings
 ---
-
-CSci 1301: Problem Set 1
-------------------------
-
-#### Due: Friday, September 14 at 11:59pm
 
 Please test all your programs carefully and include all the test cases
 with your program. You must have a `check-expect` test for each

--- a/_problem_sets/pset2.md
+++ b/_problem_sets/pset2.md
@@ -1,14 +1,9 @@
 ---
 layout: problem_set
-title:  "CSci 1301: Problem Set XXX"
+title:  "Problem Set XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket problem_set expressions functions images strings
 ---
-
-CSci 1301: Problem Set 2
-------------------------
-
-#### Due: Friday, September 28 at 11:59pm by e-mail
 
 Please test all your programs carefully and include all the test cases
 with your program. You must have at least 3 `check-expect` tests for

--- a/_problem_sets/pset3.md
+++ b/_problem_sets/pset3.md
@@ -1,14 +1,9 @@
 ---
 layout: problem_set
-title:  "CSci 1301: Problem Set XXX"
+title:  "Problem Set XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket problem_set
 ---
-
-CSci 1301: Problem Set 3
-------------------------
-
-#### Due: Thursday, October 25th at 11:59pm by e-mail
 
 Please make sure that every function has a signature, description, and
 test cases (as needed).

--- a/_problem_sets/pset4.md
+++ b/_problem_sets/pset4.md
@@ -1,14 +1,9 @@
 ---
 layout: problem_set
-title:  "CSci 1301: Problem Set XXX"
+title:  "Problem Set XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket problem_set
 ---
-
-CSci 1301: Problem Set 4
-------------------------
-
-#### Due: Monday, November 12th at 11:59pm
 
 Please make sure that every function has a signature, description, and
 test cases (as needed).
@@ -77,7 +72,7 @@ in the textbook and do the following exercises:
                     (check-expect (prefixes (list "a")) (list empty (list "a")))
                     ;; base case:
                     (check-expect (prefixes empty) (list empty))
-                
+
 
     -   The smallest list of letters (and the smallest prefix) is a
         one-letter list. Then your base case is when the list of letters
@@ -86,7 +81,7 @@ in the textbook and do the following exercises:
                     (check-expect (prefixes (list "a" "b" "c")) (list (list "a") (list "a" "b") (list "a" "b" "c")))
                     ;; base case:
                     (check-expect (prefixes (list "a")) (list (list "a")))
-                
+
 
     Both approaches have their challenges, but can be solved by
     carefully thinking of a solution in terms of the recursive case and

--- a/_problem_sets/pset5.md
+++ b/_problem_sets/pset5.md
@@ -1,14 +1,9 @@
 ---
 layout: problem_set
-title:  "CSci 1301: Problem Set XXX"
+title:  "Problem Set XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket problem_set
 ---
-
-CSci 1301: Problem Set 5
-------------------------
-
-#### Due: Wednesday, Decemeber 5th at 11:59pm
 
 Please make sure that every function has a signature, description, and
 test cases (as needed).

--- a/_problem_sets/pset6.md
+++ b/_problem_sets/pset6.md
@@ -1,14 +1,9 @@
 ---
 layout: problem_set
-title:  "CSci 1301: Problem Set XXX"
+title:  "Problem Set XXX"
 date:   2019-08-13 10:28:34 -0500
 categories: racket problem_set
 ---
-
-CSci 1301: Problem Set 6
-------------------------
-
-#### Due: Wednesday, December 12 at 11:59pm
 
 You are required to write signatures and descriptions for all functions,
 and also descriptions of all your structures. Additionally, functions,

--- a/index.md
+++ b/index.md
@@ -8,25 +8,29 @@ layout: home
 
 <h1>Problem sets</h1>
 
+<ul>
 {% for problem_set in site.problem_sets %}
-  <h2>
+  <li>
     <a href="{{ problem_set.url }}">
       {{ problem_set.title }}
     </a>
-  </h2>
+  </li>
 {% endfor %}
+</ul>
 
 <hr>
 
 <h1>Labs</h1>
 
+<ul>
 {% for lab in site.labs %}
- <h2>
+ <li>
   <a href="{{ lab.url }}">
     {{ lab.title }}
   </a>
- </h2>
+ </li>
 {% endfor %}
+</ul>
 
 <hr>
 


### PR DESCRIPTION
All the labs and problem set titles had "CSci 1301: " in front of them, which was
unnecessary clutter, so I removed all that. They also had things like "CSci 1301: Lab 1"
at the top of each page, which was duplicated by the title, so I deleted that,
along with the due dates, which will live on Canvas.

Lastly, I updated `index.html` so that the display of the problem sets and labs are
in an unordered list instead of a sequence of big `<h2>` elements.